### PR TITLE
Parse config when user has client certs for authorisation

### DIFF
--- a/examples/florp_controller.cr
+++ b/examples/florp_controller.cr
@@ -43,7 +43,7 @@ def florp_spec(florp : Kubernetes::Resource(Florp))
     selector: {matchLabels: labels},
     template: {
       metadata: {labels: labels},
-      spec: {
+      spec:     {
         containers: [
           {
             image:   "busybox:latest",
@@ -65,7 +65,7 @@ def env(**args)
     .new(initial_capacity: args.size)
 
   args.each do |key, value|
-    array << { name: key.to_s, value: value }
+    array << {name: key.to_s, value: value}
   end
 
   array

--- a/examples/svcapp_controller.cr
+++ b/examples/svcapp_controller.cr
@@ -30,7 +30,7 @@ k8s.watch_serviceapps do |watch|
         selector: {matchLabels: labels},
         template: {
           metadata: {labels: labels},
-          spec: {
+          spec:     {
             containers: [
               {
                 image:   svcapp.spec.image,
@@ -52,9 +52,9 @@ k8s.watch_serviceapps do |watch|
       kind: "Service",
       metadata: metadata,
       spec: {
-        type: "ClusterIP",
-        selector: labels,
-        ports: [{ port: 3000 }],
+        type:            "ClusterIP",
+        selector:        labels,
+        ports:           [{port: 3000}],
         sessionAffinity: "None",
       },
     )
@@ -79,10 +79,10 @@ k8s.watch_serviceapps do |watch|
                   backend: {
                     service: {
                       name: metadata[:name],
-                      port: { number: 3000 },
+                      port: {number: 3000},
                     },
                   },
-                  path: "/",
+                  path:     "/",
                   pathType: "Prefix",
                 },
               ],

--- a/src/kubernetes.cr
+++ b/src/kubernetes.cr
@@ -45,12 +45,12 @@ module Kubernetes
 
       user = user_entry.user
 
-      if user.client_certificate_data && user.client_key_data
+      if (cert = user.client_certificate_data) && (key = user.client_key_data)
         client_cert_file = File.tempfile prefix: "kubernetes", suffix: ".crt" do |tempfile|
-          Base64.decode user.client_certificate_data.not_nil!, tempfile
+          Base64.decode cert, tempfile
         end
         private_key_file = File.tempfile prefix: "kubernetes", suffix: ".crt" do |tempfile|
-          Base64.decode user.client_key_data.not_nil!, tempfile
+          Base64.decode key, tempfile
         end
         at_exit { client_cert_file.delete; private_key_file.delete }
 

--- a/src/kubernetes.cr
+++ b/src/kubernetes.cr
@@ -1261,10 +1261,8 @@ module Kubernetes
 
         field exec : Exec?
 
-        @[YAML::Field(key: "client-certificate-data")]
-        property client_certificate_data : String?
-        @[YAML::Field(key: "client-key-data")]
-        property client_key_data : String?
+        field client_certificate_data : String?, key: "client-certificate-data"
+        field client_key_data : String?, key: "client-key-data"
 
         def credential
           if exec = self.exec


### PR DESCRIPTION
Support authorisation with client certificates from config file. Example:

```
users:
- name: admin@k3d-k3s-default
  user:
    client-certificate-data: LS0tLS1CRUdJTiBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
    client-key-data: LS0tLS1CRUdJTiBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
```

## Problem

I had an exception: `Cannot figure out how to get credentials for`

## Solution

A bit update the code to check for two keys `client-certificate-data` and `client-key-data` to cover that case.

## Tophat

Create a sample k3s cluster with:

```
$ k3d cluster create
```

Then run code:

```crystal
require "kubernetes"

k8s = Kubernetes::Client.from_config
pp k8s.deployments
```

Printed:

```
Kubernetes::List(Kubernetes::Deployment)(
 @api_version="apps/v1",
 @kind="DeploymentList",
 @metadata=
  Kubernetes::Metadata(
   @name="",
   @resource_version="2388",
   @creation_timestamp=0001-01-01 00:00:00.0 UTC),
```